### PR TITLE
Move cmd_line_options back to `environment`

### DIFF
--- a/mesonbuild/environment.py
+++ b/mesonbuild/environment.py
@@ -331,7 +331,7 @@ class Environment:
             os.makedirs(self.log_dir, exist_ok=True)
             os.makedirs(self.info_dir, exist_ok=True)
             try:
-                self.coredata = coredata.load(self.get_build_dir(), options)
+                self.coredata = coredata.load(self.get_build_dir())
                 self.first_invocation = False
             except FileNotFoundError:
                 self.create_new_coredata(options)
@@ -388,6 +388,8 @@ class Environment:
                 'exe_wrapper')
         else:
             self.exe_wrapper = None
+
+        self.cmd_line_options = options.cmd_line_options.copy()
 
         # List of potential compilers.
         if mesonlib.is_windows():
@@ -1036,7 +1038,7 @@ class Environment:
     def detect_compilers(self, lang: str, need_cross_compiler: bool):
         (comp, cross_comp) = self.compilers_from_language(lang, need_cross_compiler)
         if comp is not None:
-            self.coredata.process_new_compilers(lang, comp, cross_comp)
+            self.coredata.process_new_compilers(lang, comp, cross_comp, self.cmd_line_options)
         return comp, cross_comp
 
     def detect_static_linker(self, compiler):

--- a/mesonbuild/interpreter.py
+++ b/mesonbuild/interpreter.py
@@ -2528,7 +2528,7 @@ external dependencies (including libraries) must go to "dependencies".''')
         if self.environment.first_invocation:
             self.coredata.init_backend_options(backend)
 
-        options = {k: v for k, v in self.environment.coredata.cmd_line_options.items() if k.startswith('backend_')}
+        options = {k: v for k, v in self.environment.cmd_line_options.items() if k.startswith('backend_')}
         self.coredata.set_options(options)
 
     @stringArgs
@@ -2557,7 +2557,7 @@ external dependencies (including libraries) must go to "dependencies".''')
             default_options.update(self.default_project_options)
         else:
             default_options = {}
-        self.coredata.set_default_options(default_options, self.subproject)
+        self.coredata.set_default_options(default_options, self.subproject, self.environment.cmd_line_options)
         self.set_backend()
 
         if not self.is_subproject():

--- a/mesonbuild/mintro.py
+++ b/mesonbuild/mintro.py
@@ -219,7 +219,7 @@ class IntrospectionInterpreter(astinterpreter.AstInterpreter):
         self.project_default_options = mesonlib.stringlistify(def_opts)
         self.project_default_options = cdata.create_options_dict(self.project_default_options)
         self.default_options.update(self.project_default_options)
-        self.coredata.set_default_options(self.default_options, self.subproject)
+        self.coredata.set_default_options(self.default_options, self.subproject, self.environment.cmd_line_options)
 
         if not self.is_subproject() and 'subproject_dir' in kwargs:
             spdirname = kwargs['subproject_dir']
@@ -234,7 +234,7 @@ class IntrospectionInterpreter(astinterpreter.AstInterpreter):
                         self.do_subproject(i)
 
         self.coredata.init_backend_options(self.backend)
-        options = {k: v for k, v in self.environment.coredata.cmd_line_options.items() if k.startswith('backend_')}
+        options = {k: v for k, v in self.environment.cmd_line_options.items() if k.startswith('backend_')}
 
         self.coredata.set_options(options)
         self.func_add_languages(None, proj_langs, None)


### PR DESCRIPTION
We don't actually wish to persist something this unstructured, so we
shouldn't make it a field on `coredata`. It would also be data
denormalization since the information we already store in coredata
depends on the CLI args.